### PR TITLE
chore: bump API version

### DIFF
--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -145,7 +145,7 @@ class ShopifySDK
     /**
      * @var string Default Shopify API version
      */
-    public static $defaultApiVersion = '2022-07';
+    public static $defaultApiVersion = '2024-01';
 
     /**
      * Shop / API configurations


### PR DESCRIPTION
Bumping to the latest stable version

https://shopify.dev/docs/api/release-notes/2024-01

